### PR TITLE
rhel improvements, image size reduction, & arb uid support added

### DIFF
--- a/Openshift/4.6.0/Dockerfile
+++ b/Openshift/4.6.0/Dockerfile
@@ -4,31 +4,28 @@ FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Couchbase Docker Team <docker@couchbase.com>
 
+COPY help.md /tmp/
 
 # Install yum dependencies
-RUN yum install -y tar \
-    && yum clean all && \
-      yum -y install openssl \
-      lsof lshw net-tools numactl \
-      sysstati wget screen psmisc zip unzip \
-      gzip
+RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms \
+    INSTALL_PKGS="golang-github-cpuguy83-go-md2man openssl lsof lshw \
+      net-tools numactl sysstat wget screen psmisc zip unzip" && \
+    yum -y update-minimal --disablerepo "*" --enablerepo rhel-7-server-rpms --setopt=tsflags=nodocs \
+      --security --sec-severity=Important --sec-severity=Critical && \
+    yum -y install --disablerepo "*" --enablerepo ${REPOLIST} --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    go-md2man -in /tmp/help.md -out /help.1 && rm -f /tmp/help.md && \
+#clean the cache
+    yum clean all
 
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - ; pip install httplib2
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - && \
+    pip install --no-cache-dir httplib2
 
 COPY functions /etc/init.d/
-
-# Install gosu for startup script
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.4/gosu-amd64" \
-    && curl -o /usr/local/bin/gosu.asc -sSL "https://github.com/tianon/gosu/releases/download/1.4/gosu-amd64.asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
-    && rm /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu
+COPY licenses /licenses
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)
-RUN groupadd -g1000 couchbase && \
-    useradd couchbase -g couchbase -u1000 -m -s /bin/bash && \
+RUN useradd couchbase -g 0 -u1000 -m -s /bin/bash && \
     echo 'couchbase:couchbase' | chpasswd
 
 ENV CB_VERSION=4.6.0 \
@@ -37,28 +34,29 @@ ENV CB_VERSION=4.6.0 \
     PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Install couchbase
-RUN rpm --install $CB_RELEASE_URL/$CB_VERSION/$CB_PACKAGE
-
-#clean the cache
-RUN yum clean all
-
+RUN rpm --install $CB_RELEASE_URL/$CB_VERSION/$CB_PACKAGE && \
+    chown -R couchbase:0 /opt/couchbase && \
+    chmod -R g=u /opt/couchbase
 
 COPY scripts/couchbase-start /usr/local/bin/
 
-LABEL Name=rhel7/couchbase-server
-LABEL Release=Latest 
-LABEL Vendor=Couchbase 
-LABEL Version=4.6.0 
-LABEL Architecture="x86_64"
-LABEL RUN="docker run -d --rm --privileged -p 8091:8091 --restart always --name NAME IMAGE \
+LABEL name=rhel7/couchbase-server
+LABEL release=Latest 
+LABEL vendor=Couchbase 
+LABEL version=${CB_VERSION} 
+LABEL architecture="x86_64"
+LABEL summary="Couchbase"
+LABEL description="Couchbase will ....."
+LABEL run="docker run -d --rm --privileged -p 8091:8091 --restart always --name NAME IMAGE \
             -v /opt/couchbase/var:/opt/couchbase/var \
             -v /opt/couchbase/var/lib/moxi:/opt/couchbase/var/lib/moxi \
             -v /opt/couchbase/var/lib/stats:/opt/couchbase/var/lib/stats "
 
+USER 1000
 
 ENTRYPOINT ["couchbase-start"]
 CMD ["couchbase-server", "--", "-noinput"]
 # pass -noinput so it doesn't drop us in the erlang shell
 
 EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
-#VOLUME /opt/couchbase/var
+VOLUME /opt/couchbase/var

--- a/Openshift/4.6.0/help.md
+++ b/Openshift/4.6.0/help.md
@@ -1,0 +1,40 @@
+% IMAGE_NAME(1)
+% MAINTAINER
+% DATE
+
+# DESCRIPTION
+Describe in greater detail the role or purpose of the image.  This can include more specifics about the
+packages that make up the image.  You can also describe whether image is meant to be interactive
+or more service oriented.
+
+# USAGE
+Describe how to run the image as a container and what factors might influence the behaviour of the image
+itself. For example:
+
+To set up the host system for use by the XYZ container, run:
+
+  atomic install XYZimage
+
+To run the XYZ container (after it is installed), run:
+
+  atomic run XYZimage
+
+To remove the XYZ container (not the image) from your system, run:
+
+  atomic uninstall XYZimage
+
+To upgrade the XYZ container from your system, run:
+
+  atomic upgrade XYZimage
+
+# LABELS
+Describe LABEL settings (from the Dockerfile that created the image) that contains pertinent information.
+For containers run by atomic, that could include INSTALL, RUN, UNINSTALL, and UPDATE LABELS. Others could
+include BZComponent, Name, Version, Release, and Architecture.
+
+# SECURITY IMPLICATIONS
+If you expose ports or run with privileges, it would be warranted to briefly note those and provide
+an explanation if needed.
+
+# HISTORY
+Similar to a Changelog of sorts which can be as detailed as the maintainer wishes.

--- a/Openshift/4.6.0/scripts/couchbase-start
+++ b/Openshift/4.6.0/scripts/couchbase-start
@@ -6,12 +6,6 @@ set -e
 
 if [ "$1" = 'couchbase-server' ]
 then
-
-    if [ "$(id -u)" != "0" ]; then
-        echo "This script must be run as root"
-        exit 1
-    fi
-
     # Create directories where couchbase stores its data
     cd /opt/couchbase
     mkdir -p var/lib/couchbase \
@@ -20,11 +14,9 @@ then
         var/lib/couchbase/stats \
         var/lib/couchbase/logs \
         var/lib/moxi
-    chown -R couchbase:couchbase var
 
     # Start couchbase
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:8091"
-    exec gosu couchbase "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
With these mods, the image should run in any openshift env w/o the need for elevated rights.
The image size is cut in half.
The image should pass certification scan.